### PR TITLE
fixes #1 (bat not working if username has spaces)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ echo First line of %pyscript% does not start with "#!"
 exit /b 1
 :goodstart
 set py_exe=%line1:~2%
-call %py_exe% %pyscript% %*
+call "%py_exe%" %pyscript% %*
 """
 
 


### PR DESCRIPTION
Quoting the %py_exe% call makes it work.
